### PR TITLE
Exclude injected properties from computed properties list

### DIFF
--- a/addon-test-support/ember-object.js
+++ b/addon-test-support/ember-object.js
@@ -109,7 +109,15 @@ function parseMeta(meta = {}) {
 
   const computedProperties = [];
   meta.forEachDescriptors((name, desc) => {
-    if (desc.enumerable && ownProperties.includes(name)) {
+    const descProto = Object.getPrototypeOf(desc) || {};
+    const constructorName = descProto.constructor
+      ? descProto.constructor.name
+      : "";
+    if (
+      desc.enumerable &&
+      ownProperties.includes(name) &&
+      constructorName === "ComputedProperty"
+    ) {
       computedProperties.push(name);
     }
   });

--- a/tests/helpers/ember-object-mocker.js
+++ b/tests/helpers/ember-object-mocker.js
@@ -3,6 +3,7 @@ import { sum } from "@ember/object/computed";
 import EmberObject, { computed, observer } from "@ember/object";
 import { on } from "@ember/object/evented";
 import Mixin from "@ember/object/mixin";
+import { inject as service } from "@ember/service";
 
 // MIXINS
 const LogMixin = Mixin.create({
@@ -71,6 +72,11 @@ const mockEmberObject = Base.extend(DifferenceMixin, {
   value: "",
   filterProp: 5,
   product: "",
+  maps: service(),
+
+  ratio1: computed("number1", "number2", function() {
+    return this.number1 / this.number2;
+  }),
 
   difference: observer("number1", "number2", function() {
     return this.number1 - this.number2;
@@ -90,7 +96,7 @@ const mockEmberObject = Base.extend(DifferenceMixin, {
 });
 
 const mockEmberObjectParsedMeta = {
-  computedProperties: [],
+  computedProperties: ["ratio1"],
   observedProperties: ["number1", "number2"],
   observerProperties: {
     difference: ["number1", "number2"]
@@ -106,6 +112,8 @@ const mockEmberObjectParsedMeta = {
     "value",
     "filterProp",
     "product",
+    "maps",
+    "ratio1",
     "difference",
     "init",
     "getAddition"


### PR DESCRIPTION
Currently the injected properties are also listed as computed properties in the metadata. 

The injected properties are extended from computed properties so they are populated as descriptors. There is no straightforward way to check whether a property is injected or computed. 

We are using `constructor.name` to figure out whether a property is computed or injected.